### PR TITLE
refactor(unix/apm): change `?apm` parameter to take `Skapm.Span.parent`

### DIFF
--- a/skrest.opam
+++ b/skrest.opam
@@ -13,7 +13,6 @@ depends: [
   "lwt" {>= "4.0.0"}
   "lwt_ppx" {>= "2.0.0"}
   "cohttp" {>= "2.5.4"}
-  "cohttp-lwt" {>= "2.5.4"}
   "mdx" {>= "1.7.0" & with-test}
   "rresult" {>= "0.6.0"}
   "uri" {>= "3.0.0"}

--- a/unix/skrest_unix.ml
+++ b/unix/skrest_unix.ml
@@ -28,7 +28,7 @@ module Apm = struct
   let name ~methd ~uri = Fmt.str "%s: %s" methd (Uri.to_string uri)
 
   let wrap
-      ?(apm : Skapm.Transaction.t option)
+      ?(apm : Skapm.Span.parent option)
       ?(apm_tags : Skapm.Tag.t list option)
       ~name
       ~subtype
@@ -37,11 +37,11 @@ module Apm = struct
       x =
     let open Lwt in
     match apm with
-    | Some t ->
+    | Some parent ->
       let context = Skapm.Span.Context.make ?tags:apm_tags () in
       let span =
-        Skapm.Span.make_span ~context ~parent:(`Transaction t) ~name
-          ~type_:"Web Request" ~subtype ~action ()
+        Skapm.Span.make_span ~context ~parent ~name ~type_:"Web Request"
+          ~subtype ~action ()
       in
       f x >|= fun res ->
       let (_ : Skapm.Span.result) = Skapm.Span.finalize_and_send span in
@@ -52,7 +52,7 @@ module Apm = struct
       ?(ctx : ctx option)
       ?(headers : Cohttp.Header.t option)
       ?(timeout : float option)
-      ?(apm : Skapm.Transaction.t option)
+      ?(apm : Skapm.Span.parent option)
       ?(apm_tags : Skapm.Tag.t list option)
       (uri : Uri.t) =
     let run = head ?ctx ?headers ?timeout in
@@ -63,7 +63,7 @@ module Apm = struct
       ?(ctx : ctx option)
       ?(headers : Cohttp.Header.t option)
       ?(timeout : float option)
-      ?(apm : Skapm.Transaction.t option)
+      ?(apm : Skapm.Span.parent option)
       ?(apm_tags : Skapm.Tag.t list option)
       ~(follow : int)
       (uri : Uri.t) =
@@ -75,7 +75,7 @@ module Apm = struct
       ?(ctx : ctx option)
       ?(headers : Cohttp.Header.t option)
       ?(timeout : float option)
-      ?(apm : Skapm.Transaction.t option)
+      ?(apm : Skapm.Span.parent option)
       ?(apm_tags : Skapm.Tag.t list option)
       (uri : Uri.t) =
     let run = delete ?ctx ?headers ?timeout in
@@ -88,7 +88,7 @@ module Apm = struct
       ?(headers : Cohttp.Header.t option)
       ?(timeout : float option)
       ?(body : Cohttp_lwt.Body.t option)
-      ?(apm : Skapm.Transaction.t option)
+      ?(apm : Skapm.Span.parent option)
       ?(apm_tags : Skapm.Tag.t list option)
       (uri : Uri.t) =
     let run = patch ?ctx ?headers ?timeout ?body in
@@ -100,7 +100,7 @@ module Apm = struct
       ?(headers : Cohttp.Header.t option)
       ?(timeout : float option)
       ?(body : Cohttp_lwt.Body.t option)
-      ?(apm : Skapm.Transaction.t option)
+      ?(apm : Skapm.Span.parent option)
       ?(apm_tags : Skapm.Tag.t list option)
       (uri : Uri.t) =
     let run = post ?ctx ?headers ?timeout ?body in
@@ -111,7 +111,7 @@ module Apm = struct
       ?(ctx : ctx option)
       ?(headers : Cohttp.Header.t option)
       ?(timeout : float option)
-      ?(apm : Skapm.Transaction.t option)
+      ?(apm : Skapm.Span.parent option)
       ?(apm_tags : Skapm.Tag.t list option)
       ~(params : (string * string list) list)
       (uri : Uri.t) =
@@ -124,7 +124,7 @@ module Apm = struct
       ?(headers : Cohttp.Header.t option)
       ?(timeout : float option)
       ?(body : Cohttp_lwt.Body.t option)
-      ?(apm : Skapm.Transaction.t option)
+      ?(apm : Skapm.Span.parent option)
       ?(apm_tags : Skapm.Tag.t list option)
       (methd : Cohttp.Code.meth)
       (uri : Uri.t) =


### PR DESCRIPTION
This means that we can pass spans *or* transactions to the calls, which produces nicer and more accurate waterfall graphs.