### PR TITLE
fix(js): headers not being set on JS

### DIFF
--- a/js/skrest_js.ml
+++ b/js/skrest_js.ml
@@ -7,7 +7,9 @@ module Backend : Skrest.Backend = struct
 
   let sleep = Js_of_ocaml_lwt.Lwt_js.sleep
 
-  let inject_headers _ = Cohttp.Header.init ()
+  let inject_headers = function
+    | Some h -> h
+    | None -> Cohttp.Header.init ()
 
   let handle_exn = function
     | Js.Error err ->


### PR DESCRIPTION
Before I was accidentally throwing away the headers if they existed. Before _that_, the headers would refuse to set because they contained `connection`. Oy, gevalt!