### PR TITLE
feat(unix): add more info to APM

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,15 @@ jobs:
           - 4.12.1
 
     runs-on: ${{ matrix.os }}
+    
+    services:
+      httpbin:
+        image: kennethreitz:httpbin
+        ports:
+          - 80:8700
+
+    env:
+      HTTPBIN: http://localhost:8700
 
     steps:
       - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       httpbin:
         image: kennethreitz/httpbin
         ports:
-          - 80:8700
+          - 8700:80
 
     env:
       HTTPBIN: http://localhost:8700

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     
     services:
       httpbin:
-        image: kennethreitz:httpbin
+        image: kennethreitz/httpbin
         ports:
           - 80:8700
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           opam-depext: false
           opam-pin: false
 
-      - run: opam pin add skapm.dev -n https://github.com/skolemlabs/skapm.git
+      - run: opam pin add skapm.1.6.0 -n https://github.com/skolemlabs/skapm.git#1.6.0
       - run: opam pin add skrest.dev -n .
       - run: opam pin add skrest_js.dev -n .
       - run: opam pin add skrest_unix.dev -n .

--- a/dune-project
+++ b/dune-project
@@ -52,7 +52,7 @@
  (name skrest_unix)
  (synopsis "Simple wrapper on top of the Cohttp Unix client")
  (depends
-  skapm
+  (skapm (and (>= 1.6.0) (< 1.7.0)))
   (ocaml
    (>= 4.08.0))
   (cohttp-lwt-unix

--- a/skrest_unix.opam
+++ b/skrest_unix.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/skolemlabs/skrest"
 bug-reports: "https://github.com/skolemlabs/skrest/issues"
 depends: [
   "dune" {>= "3.0"}
-  "skapm"
+  "skapm" {>= "1.6.0" & < "1.7.0"}
   "ocaml" {>= "4.08.0"}
   "cohttp-lwt-unix" {>= "2.5.4"}
   "skrest" {= version}

--- a/tests/skrest_common_tests.ml
+++ b/tests/skrest_common_tests.ml
@@ -5,7 +5,7 @@ module J_util = Yojson.Safe.Util
 
 let ( let* ) = Lwt.bind
 
-let httpbin = Uri.of_string "http://httpbin.org"
+let httpbin = Option.(value ~default:(Uri.of_string "http://httpbin.org") (map Uri.of_string (Sys.getenv_opt "HTTPBIN")))
 let pp_json = Yojson.Safe.pretty_print ~std:false
 
 module Make (M : Skrest.Impl) = struct


### PR DESCRIPTION
This utilizes the new APIs in Skapm 1.6.0, and constrains the package to require b/w 1.6.0 (inclusive) and 1.7.0 (exclusive).